### PR TITLE
Bump Microsoft.Data.OData in /FonSpa/Asset/Admin/js/Plugin/ckfinder

### DIFF
--- a/FonSpa/Asset/Admin/js/Plugin/ckfinder/packages.config
+++ b/FonSpa/Asset/Admin/js/Plugin/ckfinder/packages.config
@@ -22,7 +22,7 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.8.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />


### PR DESCRIPTION
Bumps Microsoft.Data.OData from 5.7.0 to 5.8.4.

Signed-off-by: dependabot[bot] <support@github.com>